### PR TITLE
feat(#20): agent launch + live event stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@ coverage.html
 
 # Node
 ui/node_modules/
+agent/node_modules/
 
 # SPA build output
 ui/dist/
+
+# Agent bridge build output
+agent/dist/
 
 # Editor
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# Build stage: compile the mirdain-bridge TypeScript module.
+FROM node:20-slim AS bridge-builder
+WORKDIR /agent
+COPY agent/package.json ./
+RUN npm install
+COPY agent/ ./
+RUN npm run build
+
+# Runtime image.
 FROM node:20-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -15,12 +24,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# TODO(#21): install Pi (badlogic/pi-mono) and the mirdain-bridge extension.
-# Example (version must be pinned once decided):
-#   RUN npm install -g <pi-package>
-#   COPY agent/dist/ /app/bridge/
+# Copy the compiled bridge and its runtime dependencies.
+COPY --from=bridge-builder /agent/dist /app/dist
+COPY --from=bridge-builder /agent/node_modules /app/node_modules
 
 # Directory layout required by the container spec (see #1).
 RUN mkdir -p /workspace /run/secrets /skills
 
 WORKDIR /workspace
+
+# Requires MIRDAIN_RUN_ID, MIRDAIN_RUN_SECRET, and MIRDAIN_ORCHESTRATOR_URL.
+CMD ["node", "/app/dist/bridge.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build ui-build run test image e2e
+.PHONY: build ui-build agent-build run test image e2e
 
 BIN := bin/mirdain
 
@@ -8,6 +8,9 @@ build: ui-build
 
 ui-build:
 	cd ui && npm install && npm run build
+
+agent-build:
+	cd agent && npm install && npm run build
 
 run: build
 	./$(BIN)

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,0 +1,159 @@
+# Ubiquitous Language
+
+> Semantics-only. No implementation details, file paths, or technology names.
+> When a concept has multiple names in use, this file is the tiebreaker.
+
+---
+
+## Actors
+
+| Term                | Definition                                                                                      | Aliases to avoid              |
+| ------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------- |
+| **Operator**        | A person who installs and configures a mirdain instance for a team or themselves                | Admin, sysadmin               |
+| **Engineer**        | A person who uses mirdain to guide work through the workflow                                    | User, developer, dev          |
+| **Agent**           | An autonomous AI actor that executes a skill within a run                                       | Bot, AI, assistant, LLM       |
+| **Bot Identity**    | The non-human account identity through which mirdain performs all writes on behalf of the agent | Bot, service account, mirdain |
+
+> An **Engineer** interacts with mirdain through the UI; an **Agent** interacts through tools. They are distinct actors even when they collaborate on the same issue.
+
+---
+
+## Workflow
+
+| Term              | Definition                                                                                              | Aliases to avoid             |
+| ----------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| **Workflow**      | The full staged pipeline from raw idea to merged pull request                                           | Pipeline, process, lifecycle |
+| **Phase**         | A named, discrete step in the workflow (design, PRD, planned, in-review, done, bug-triage)              | Stage, step, state, status   |
+| **Gate**          | A decision point between two consecutive phases; either `human` (blocks until approved) or `auto`      | Transition, checkpoint       |
+| **Feature Track** | The workflow path for new features: design → PRD → planned → in-review → done                          | Feature flow, feature path   |
+| **Bug Track**     | The workflow path for defects: bug-triage → planned → in-review → done                                 | Bug flow, hotfix path        |
+| **Direct Entry**  | The shortcut path where an issue enters at `planned` without passing through design or PRD phases       | Fast track, bypass           |
+
+---
+
+## Tracker & Issues
+
+| Term                  | Definition                                                                                                      | Aliases to avoid                    |
+| --------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Tracker**           | The external system of record for all durable workflow state: issues, labels, comments, and pull requests       | Issue tracker, GitHub, ticket board |
+| **Issue**             | A single unit of work in the tracker; the primary contract between engineer and agent                           | Ticket, task, card, story           |
+| **Pull Request**      | The code-change proposal produced by the agent during the `in-review` phase                                     | PR, diff, patch                     |
+| **Label**             | A tag applied to an issue; mirdain uses two orthogonal label namespaces: **Workflow Label** and **Status Flag** | Tag, attribute                      |
+| **Workflow Label**    | A label encoding which phase an issue is currently in; mutually exclusive — exactly one per active issue        | Phase label, state label            |
+| **Status Flag**       | A label encoding runtime health or operational status; orthogonal to the workflow label; multiple may coexist   | Runtime label, flag label           |
+| **Tenancy Marker**    | The single label that opts an issue into mirdain management; the reconciler ignores any issue lacking it        | Opt-in label, mirdain label         |
+| **Eligible Issue**    | An issue that the reconciler considers actionable: carries the tenancy marker, has a workflow label, and no blocking status flag | Actionable issue, ready issue |
+
+---
+
+## Agent Execution
+
+| Term            | Definition                                                                                                                          | Aliases to avoid                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **Run**         | A single invocation of an agent to execute a skill against a specific issue                                                         | Session, job, task, execution            |
+| **Run Mode**    | Whether a run is interactive (HITL) or autonomous (AFK)                                                                             | Run type, mode                           |
+| **HITL Run**    | A run where the engineer is in live conversation with the agent via the UI; the agent pauses at `awaiting_input` events             | Interactive run, live run, chat run      |
+| **AFK Run**     | A run where the agent acts autonomously without human interaction; it runs to completion or failure without pausing                 | Autonomous run, background run, headless |
+| **Skill**       | A markdown document with structured frontmatter declaring an agent's objective, required tools, and model class for a workflow phase | Prompt, system prompt, agent script      |
+| **Artifact**    | A named, structured output produced by an agent during a run (e.g. a PRD document, an issue decomposition)                         | Output, result, deliverable              |
+| **Run Config**  | The set of parameters passed to an agent at the start of a run (which issue, which skill, which repo, secrets)                     | Agent config, launch params              |
+| **Model Class** | An abstract LLM tier (`small`, `medium`, `large`) declared by a skill; resolved to a concrete model by the operator config          | Model size, LLM tier, model type         |
+
+---
+
+## PR Feedback Loop
+
+| Term                | Definition                                                                                                          | Aliases to avoid                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| **Feedback Loop**   | The automated cycle in which agents react to pull request events, iterate on code, and drive the PR to merge        | PR loop, review loop, CI loop    |
+| **Wake Event**      | Any event that triggers a new agent invocation in the feedback loop (comment, review, CI status change, branch push) | Trigger, notification, hook      |
+| **Failure Budget**  | The maximum number of feedback-loop iterations allowed on a PR; when exhausted, the issue is escalated to a human  | Iteration cap, retry limit       |
+| **Debounce Window** | A short configurable time window within which multiple wake events are coalesced into a single agent invocation     | Burst window, cooldown, throttle |
+
+---
+
+## Infrastructure
+
+| Term            | Definition                                                                                                           | Aliases to avoid               |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **AgentRunner** | The component responsible for launching and terminating agent containers on behalf of the orchestrator               | Executor, scheduler, launcher  |
+| **Container**   | The isolated, ephemeral runtime environment in which an agent executes a run                                         | Sandbox, VM, process           |
+| **Workspace**   | A persistent storage volume mounted into a container, holding the repository clone and the agent's working files     | Working directory, volume, dir |
+
+---
+
+## Brokered Writes & Tools
+
+| Term               | Definition                                                                                                                    | Aliases to avoid                   |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **Brokered Write** | Any write operation that an agent requests through the orchestrator rather than performing directly against the external system | Direct write, agent write          |
+| **Tool**           | A named, typed operation that an agent may invoke during a run; write tools are always brokered                               | Function, action, command, API     |
+| **Tool Surface**   | The complete set of tools available to an agent for a given skill, declared in the skill's frontmatter and validated at load  | Tool set, API surface, tool schema |
+
+---
+
+## Configuration & Capabilities
+
+| Term                | Definition                                                                                           | Aliases to avoid                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Operator Config** | The global configuration file on the host machine; owned and edited by the operator                  | Global config, server config        |
+| **Repo Config**     | The per-repository configuration file committed to the target repository; owned by the engineering team | Project config, local config      |
+| **Cap**             | A configurable hard limit on a run's resource consumption (wall-clock time, PR iteration count)       | Limit, budget, quota                |
+| **Polling Interval** | The frequency at which the reconciler checks the tracker for issues eligible for action              | Check interval, poll rate, interval |
+
+---
+
+## System Roles (at concept level)
+
+| Term             | Definition                                                                                                                        | Aliases to avoid               |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Orchestrator** | The central mirdain process; manages the workflow, brokers all writes, and coordinates agents across repositories                  | Server, backend, controller    |
+| **Reconciler**   | The component within the orchestrator that continuously polls the tracker and initiates or queues runs for eligible issues        | Poller, watcher, scheduler     |
+| **Bridge**       | The component running inside an agent container that mediates between the agent harness and the orchestrator's WebSocket protocol | Adapter, plugin, shim, harness |
+
+---
+
+## Relationships
+
+- A **Workflow** consists of one or more ordered **Phases** connected by **Gates**.
+- An **Issue** is in exactly one **Phase** at a time, indicated by its **Workflow Label**.
+- An **Issue** carries exactly one **Tenancy Marker** and zero or more **Status Flags**.
+- An **Eligible Issue** produces at most one active **Run** at a time.
+- A **Run** executes exactly one **Skill** against exactly one **Issue**.
+- A **Run** is either a **HITL Run** or an **AFK Run** — the **Run Mode** is determined by the phase and skill.
+- An **Agent** may produce one or more **Artifacts** within a single **Run**.
+- A **Brokered Write** is always initiated by an **Agent** invoking a **Tool** and fulfilled by the **Orchestrator**.
+- A **Pull Request** is associated with exactly one **Issue**; it is the entry condition for the `in-review` phase.
+- **Wake Events** on a **Pull Request** trigger new **Runs** within the **Feedback Loop**.
+- Each **Feedback Loop** invocation consumes one unit of the **Failure Budget**.
+
+---
+
+## Example dialogue
+
+> **Engineer:** "I filed a new issue — when will the **agent** pick it up?"
+>
+> **Domain expert:** "Only once it's an **eligible issue**: it needs the **tenancy marker** plus a **workflow label** showing which **phase** it's in. Without both, the **reconciler** ignores it entirely."
+>
+> **Engineer:** "I added both. The agent started a **run** and produced a PRD **artifact**. What happens next?"
+>
+> **Domain expert:** "The PRD phase ends at a **gate**. If that gate is set to `human`, the issue stays in the `prd` **phase** until you approve it and advance the **workflow label** to `planned`. If it's `auto`, the orchestrator advances it immediately."
+>
+> **Engineer:** "Once it's `planned`, what does the agent do?"
+>
+> **Domain expert:** "The **reconciler** picks it up and starts an **AFK run** — the agent opens a **pull request** autonomously. From that point on, the **feedback loop** takes over: every **wake event** on the PR (a CI failure, a review comment, a new push) triggers a fresh **run** until the PR merges or the **failure budget** runs out."
+>
+> **Engineer:** "What if the agent gets stuck?"
+>
+> **Domain expert:** "When the **failure budget** is exhausted, the orchestrator sets the `needs-human` **status flag** on the issue. That blocks any further automatic **runs** until you clear the flag."
+
+---
+
+## Flagged ambiguities
+
+- **"Stage" vs "Phase"**: the constitution's prose uses both interchangeably. **Phase** is canonical. "Stage" appears only in repo-config YAML keys (`stages:`) as a config concept, not a domain term — do not use it when describing the workflow to a domain expert.
+- **"Agent" overload**: "agent" is used to mean (a) the AI actor persona and (b) the running container. The canonical split is: **Agent** = the AI actor; **Run** = a single execution; **Container** = the execution environment. Never say "the agent is running" when you mean "there is an active run."
+- **"Bot"**: used in the constitution to mean the **Bot Identity** (the GitHub account). Do not conflate with **Agent** (the AI actor). The bot identity is how writes appear externally; the agent is the decision-maker internally.
+- **"Skill" vs "phase" mapping**: configs map phases to skills (`stages: design: brainstorming`). This is a configuration concern. In domain conversation, say "the **brainstorming** skill handles the design phase", not "the design stage runs the brainstorming prompt."
+- **"Label" ambiguity**: "label" alone is ambiguous. Always qualify: **workflow label**, **status flag**, or **tenancy marker**. Reserve bare "label" only when the namespace is already established from context.
+- **"Tracker" vs specific backend**: **Tracker** is the domain concept. The backing technology is an implementation detail. Domain conversations should never need to name the specific tracker system.

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,0 +1,81 @@
+{
+  "name": "mirdain-bridge",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mirdain-bridge",
+      "version": "0.0.1",
+      "dependencies": {
+        "ws": "^8.16.0"
+      },
+      "devDependencies": {
+        "@types/ws": "^8.5.10",
+        "typescript": "^5.3.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mirdain-bridge",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "ws": "^8.16.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.10",
+    "typescript": "^5.3.0"
+  }
+}

--- a/agent/src/bridge.ts
+++ b/agent/src/bridge.ts
@@ -1,16 +1,34 @@
-// TODO(#21): mirdain-bridge Pi extension.
-//
-// This module connects to the orchestrator WebSocket and:
-//   - Emits structured run events:
-//       run.started, text.delta, tool.call, artifact.produced, run.completed
-//   - Receives orchestrator messages:
-//       tool.result (response to a brokered tool call)
-//       user.message (HITL input, handled in #7)
-//   - Executes brokered writes by sending tool.call messages and awaiting
-//     tool.result — the agent has NO direct write credentials.
-//
-// Environment variables injected by the orchestrator at container start:
-//   MIRDAIN_RUN_SECRET       — auth token for /internal/agent/{run_id}?secret=…
-//   MIRDAIN_ORCHESTRATOR_URL — ws://host:port base URL
+import WebSocket from 'ws'
 
-export {};
+// Environment variables injected by the orchestrator at container start.
+const runID = process.env.MIRDAIN_RUN_ID
+const secret = process.env.MIRDAIN_RUN_SECRET
+const orchestratorURL = process.env.MIRDAIN_ORCHESTRATOR_URL
+
+if (!runID || !secret || !orchestratorURL) {
+  console.error(
+    'mirdain-bridge: missing required env vars ' +
+      '(MIRDAIN_RUN_ID, MIRDAIN_RUN_SECRET, MIRDAIN_ORCHESTRATOR_URL)'
+  )
+  process.exit(1)
+}
+
+const wsURL = `${orchestratorURL}/internal/agent/${runID}?secret=${secret}`
+
+const ws = new WebSocket(wsURL)
+
+const now = () => new Date().toISOString()
+
+const send = (payload: object) => ws.send(JSON.stringify(payload))
+
+ws.on('open', () => {
+  send({ v: 1, type: 'run.started', run_id: runID, ts: now() })
+  send({ v: 1, type: 'text.delta', run_id: runID, ts: now(), text: 'Tracer skill running…' })
+  send({ v: 1, type: 'run.completed', run_id: runID, ts: now(), exit_code: 0 })
+  ws.close()
+})
+
+ws.on('error', (err) => {
+  console.error('mirdain-bridge: WebSocket error:', err.message)
+  process.exit(1)
+})

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cmd/mirdain/main.go
+++ b/cmd/mirdain/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,10 +12,22 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gorilla/websocket"
 	"github.com/tom-molotnikoff/mirdain-ai/internal/config"
+	"github.com/tom-molotnikoff/mirdain-ai/internal/registry"
+	"github.com/tom-molotnikoff/mirdain-ai/internal/runner"
 	"github.com/tom-molotnikoff/mirdain-ai/internal/tracker"
 	"github.com/tom-molotnikoff/mirdain-ai/ui"
 )
+
+// wsUpgrader upgrades HTTP connections to WebSocket. CheckOrigin is permissive
+// because the server binds to 127.0.0.1 only, so ambient network access is
+// already constrained.
+var wsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
 
 func main() {
 	cfg, err := config.Load("mirdain.yaml")
@@ -38,14 +52,205 @@ func main() {
 		log.Fatalf("failed to sub embedded UI fs: %v", err)
 	}
 
+	reg := registry.New()
+	agentRunner := runner.NewLocalDocker()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/issues", issuesHandler(gh))
-	// TODO(#20): mount remaining /api/ routes once AgentRunner and WS are wired.
+	mux.HandleFunc("POST /api/runs", createRunHandler(reg, agentRunner, cfg.Server.Port))
+	mux.HandleFunc("GET /api/runs/{id}", getRunHandler(reg))
+	mux.HandleFunc("GET /ws/{run_id}", uiWSHandler(reg))
+	mux.HandleFunc("GET /internal/agent/{run_id}", agentWSHandler(reg))
 	mux.Handle("/", spaHandler(distFS))
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Bind, cfg.Server.Port)
 	log.Printf("mirdain listening on http://%s", addr)
 	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+// newID returns a random 128-bit hex string suitable for use as a run ID or run secret.
+func newID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+// createRunHandler handles POST /api/runs.
+func createRunHandler(reg *registry.Registry, ar runner.AgentRunner, port int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			IssueID string `json:"issue_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.IssueID == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "issue_id is required"})
+			return
+		}
+
+		runID := newID()
+		runSecret := newID()
+
+		// Create the registry entry before starting the container — the agent
+		// needs it to authenticate its WS connection immediately on startup.
+		reg.Create(runID, runSecret, req.IssueID)
+
+		orchestratorURL := fmt.Sprintf("ws://127.0.0.1:%d", port)
+		if err := ar.Start(r.Context(), runner.RunConfig{
+			RunID:           runID,
+			RunSecret:       runSecret,
+			IssueID:         req.IssueID,
+			OrchestratorURL: orchestratorURL,
+		}); err != nil {
+			reg.Remove(runID)
+			log.Printf("POST /api/runs: %v", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{
+			"run_id": runID,
+			"status": "running",
+		})
+	}
+}
+
+// getRunHandler handles GET /api/runs/{id}.
+func getRunHandler(reg *registry.Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		runID := r.PathValue("id")
+		run, ok := reg.Get(runID)
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "run not found"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"run_id": run.RunID,
+			"status": run.StatusString(),
+		})
+	}
+}
+
+// agentWSHandler handles GET /internal/agent/{run_id}.
+// It authenticates the agent via ?secret=, then reads events and publishes
+// them to the run's event bus. On run.completed, it terminates the run.
+func agentWSHandler(reg *registry.Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		runID := r.PathValue("run_id")
+		secret := r.URL.Query().Get("secret")
+
+		run, ok := reg.Get(runID)
+		if !ok {
+			http.Error(w, "run not found", http.StatusNotFound)
+			return
+		}
+		if secret != run.Secret {
+			http.Error(w, "invalid or missing run secret", http.StatusUnauthorized)
+			return
+		}
+
+		conn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("agent WS upgrade %s: %v", runID, err)
+			return
+		}
+		defer conn.Close()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				break
+			}
+
+			// Parse just the type field to detect run.completed.
+			var envelope struct {
+				Type string `json:"type"`
+			}
+			if jsonErr := json.Unmarshal(data, &envelope); jsonErr != nil {
+				log.Printf("agent WS %s: invalid JSON: %v", runID, jsonErr)
+				continue
+			}
+
+			run.Publish(data)
+
+			if envelope.Type == "run.completed" {
+				reg.Terminate(runID)
+				return
+			}
+		}
+
+		// Connection dropped without run.completed — terminate the run.
+		reg.Terminate(runID)
+	}
+}
+
+// uiWSHandler handles GET /ws/{run_id}.
+// It streams all run events (buffered replay + live) to the connected UI client.
+func uiWSHandler(reg *registry.Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		runID := r.PathValue("run_id")
+
+		run, ok := reg.Get(runID)
+		if !ok {
+			http.Error(w, "run not found", http.StatusNotFound)
+			return
+		}
+
+		conn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("UI WS upgrade %s: %v", runID, err)
+			return
+		}
+		defer conn.Close()
+
+		snapshot, ch := run.Subscribe()
+		defer run.Unsubscribe(ch)
+
+		// Replay buffered events so late-connecting UIs don't miss anything.
+		for _, data := range snapshot {
+			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				return
+			}
+		}
+
+		// If the run is already terminated, nothing more to stream.
+		select {
+		case <-run.Done():
+			return
+		default:
+		}
+
+		// Stream live events until the run terminates or the client disconnects.
+		for {
+			select {
+			case data := <-ch:
+				if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+					return
+				}
+			case <-run.Done():
+				// Drain any events published just before termination.
+				for {
+					select {
+					case data := <-ch:
+						conn.WriteMessage(websocket.TextMessage, data) //nolint:errcheck
+					default:
+						return
+					}
+				}
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
 }
 
 // issueResponse is the JSON shape for a single issue in GET /api/issues.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/tom-molotnikoff/mirdain-ai
 
 go 1.22.0
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,148 @@
+// Package registry holds the in-memory run state for all active and recently
+// completed agent runs. Entries survive only for the lifetime of the
+// orchestrator process; they are reconciled from the tracker on restart.
+package registry
+
+import "sync"
+
+const maxEventBuffer = 1000
+
+// RunState holds the in-memory state for a single agent run.
+type RunState struct {
+	// Immutable after creation.
+	RunID   string
+	Secret  string
+	IssueID string
+
+	done chan struct{} // closed exactly once when the run terminates
+
+	mu     sync.Mutex
+	events [][]byte    // buffered raw JSON events, capped at maxEventBuffer
+	subs   []chan []byte // active UI subscriber channels
+}
+
+// Publish appends data to the event buffer and fans it out to all active
+// UI subscriber channels. Slow subscribers are skipped (non-blocking send)
+// so a stalled UI connection never blocks agent ingest.
+func (rs *RunState) Publish(data []byte) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if len(rs.events) < maxEventBuffer {
+		rs.events = append(rs.events, data)
+	}
+	for _, ch := range rs.subs {
+		select {
+		case ch <- data:
+		default:
+		}
+	}
+}
+
+// Subscribe returns a snapshot of all buffered events and a live channel for
+// new events. The caller must call Unsubscribe when it is done reading.
+func (rs *RunState) Subscribe() ([][]byte, chan []byte) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	ch := make(chan []byte, 64)
+	snapshot := make([][]byte, len(rs.events))
+	copy(snapshot, rs.events)
+	rs.subs = append(rs.subs, ch)
+	return snapshot, ch
+}
+
+// Unsubscribe removes the subscriber channel from the run's fan-out list.
+// The channel is not closed here; callers must handle the case where the
+// done channel fires instead.
+func (rs *RunState) Unsubscribe(ch chan []byte) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	for i, s := range rs.subs {
+		if s == ch {
+			rs.subs = append(rs.subs[:i], rs.subs[i+1:]...)
+			return
+		}
+	}
+}
+
+// Done returns a channel that is closed when the run terminates. Callers can
+// select on this channel alongside their subscriber channel to detect end-of-stream.
+func (rs *RunState) Done() <-chan struct{} {
+	return rs.done
+}
+
+// IsTerminated reports whether the run has terminated.
+func (rs *RunState) IsTerminated() bool {
+	select {
+	case <-rs.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// StatusString returns "terminated" or "running".
+func (rs *RunState) StatusString() string {
+	if rs.IsTerminated() {
+		return "terminated"
+	}
+	return "running"
+}
+
+// Registry is the in-memory store of all runs known to the orchestrator.
+type Registry struct {
+	mu   sync.RWMutex
+	runs map[string]*RunState
+}
+
+// New returns an empty Registry.
+func New() *Registry {
+	return &Registry{runs: make(map[string]*RunState)}
+}
+
+// Create inserts a new run with status "running" and returns it.
+func (r *Registry) Create(runID, secret, issueID string) *RunState {
+	rs := &RunState{
+		RunID:   runID,
+		Secret:  secret,
+		IssueID: issueID,
+		done:    make(chan struct{}),
+	}
+	r.mu.Lock()
+	r.runs[runID] = rs
+	r.mu.Unlock()
+	return rs
+}
+
+// Get retrieves a run by ID. Returns (nil, false) if not found.
+func (r *Registry) Get(runID string) (*RunState, bool) {
+	r.mu.RLock()
+	rs, ok := r.runs[runID]
+	r.mu.RUnlock()
+	return rs, ok
+}
+
+// Terminate marks a run as terminated by closing its done channel.
+// Safe to call multiple times; only the first call closes the channel.
+func (r *Registry) Terminate(runID string) {
+	r.mu.RLock()
+	rs, ok := r.runs[runID]
+	r.mu.RUnlock()
+	if !ok {
+		return
+	}
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	select {
+	case <-rs.done:
+		// already terminated
+	default:
+		close(rs.done)
+	}
+}
+
+// Remove deletes a run from the registry. Used to roll back a failed launch.
+func (r *Registry) Remove(runID string) {
+	r.mu.Lock()
+	delete(r.runs, runID)
+	r.mu.Unlock()
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,6 +1,12 @@
 package runner
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+)
 
 // RunConfig holds the parameters for a single agent run.
 type RunConfig struct {
@@ -13,9 +19,71 @@ type RunConfig struct {
 }
 
 // AgentRunner launches and stops containerised agent runs.
-// LocalDocker is the v1 implementation (TODO(#19)).
 // Kubernetes, Nomad, and SSH+Docker are deferred to later versions.
 type AgentRunner interface {
 	Start(ctx context.Context, cfg RunConfig) error
 	Stop(ctx context.Context, runID string) error
+}
+
+// LocalDocker implements AgentRunner using the local Docker daemon via the
+// docker CLI. It avoids the Docker SDK to keep the dependency footprint small.
+//
+// Containers use --network=host so they can reach the orchestrator on
+// 127.0.0.1. This works on Linux (the primary deployment target and CI).
+// On macOS Docker Desktop, set OrchestratorURL to ws://host.docker.internal:{port}.
+type LocalDocker struct {
+	mu           sync.Mutex
+	containerIDs map[string]string // runID → containerID
+}
+
+// NewLocalDocker returns a LocalDocker runner.
+func NewLocalDocker() *LocalDocker {
+	return &LocalDocker{containerIDs: make(map[string]string)}
+}
+
+// Start launches a mirdain-base container for the given run. The container
+// receives MIRDAIN_RUN_ID, MIRDAIN_RUN_SECRET, and MIRDAIN_ORCHESTRATOR_URL
+// as environment variables. No GitHub write credentials are injected.
+func (d *LocalDocker) Start(ctx context.Context, cfg RunConfig) error {
+	cmd := exec.CommandContext(ctx, "docker", "run", "-d",
+		"--network=host",
+		"-e", "MIRDAIN_RUN_ID="+cfg.RunID,
+		"-e", "MIRDAIN_RUN_SECRET="+cfg.RunSecret,
+		"-e", "MIRDAIN_ORCHESTRATOR_URL="+cfg.OrchestratorURL,
+		"mirdain-base",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		var stderr string
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		if stderr != "" {
+			return fmt.Errorf("docker run: %s", stderr)
+		}
+		return fmt.Errorf("docker unavailable: %w", err)
+	}
+	containerID := strings.TrimSpace(string(out))
+	d.mu.Lock()
+	d.containerIDs[cfg.RunID] = containerID
+	d.mu.Unlock()
+	return nil
+}
+
+// Stop terminates the container associated with the given run.
+func (d *LocalDocker) Stop(ctx context.Context, runID string) error {
+	d.mu.Lock()
+	containerID, ok := d.containerIDs[runID]
+	if ok {
+		delete(d.containerIDs, runID)
+	}
+	d.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "docker", "stop", containerID)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker stop %s: %w", containerID, err)
+	}
+	return nil
 }

--- a/ui/src/pages/IssueDetailPage.tsx
+++ b/ui/src/pages/IssueDetailPage.tsx
@@ -1,11 +1,41 @@
-import { useParams } from 'react-router-dom'
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 
 export default function IssueDetailPage() {
   const { id } = useParams()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const startAgent = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issue_id: id }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      const data = await res.json() as { run_id: string }
+      navigate(`/issues/${id}/runs/${data.run_id}`)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
     <main>
       <h1>Issue #{id}</h1>
-      <p>Issue detail — TODO(#20): fetch from /api/issues/{id}.</p>
+      {error && <p role="alert">Error: {error}</p>}
+      <button onClick={startAgent} disabled={loading}>
+        {loading ? 'Starting…' : 'Start agent'}
+      </button>
     </main>
   )
 }

--- a/ui/src/pages/RunDetailPage.tsx
+++ b/ui/src/pages/RunDetailPage.tsx
@@ -1,11 +1,67 @@
+import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+
+interface RunEvent {
+  v: number
+  type: string
+  run_id: string
+  ts: string
+  text?: string
+  exit_code?: number
+}
 
 export default function RunDetailPage() {
   const { id, runId } = useParams()
+  const [events, setEvents] = useState<RunEvent[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [status, setStatus] = useState<'connecting' | 'connected' | 'closed'>('connecting')
+
+  useEffect(() => {
+    if (!runId) return
+
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+    const ws = new WebSocket(`${proto}://${location.host}/ws/${runId}`)
+
+    ws.onopen = () => setStatus('connected')
+
+    ws.onmessage = (e: MessageEvent<string>) => {
+      try {
+        const event = JSON.parse(e.data) as RunEvent
+        setEvents((prev) => [...prev, event])
+      } catch {
+        // ignore malformed events
+      }
+    }
+
+    ws.onerror = () => setError('WebSocket connection error')
+
+    ws.onclose = () => setStatus('closed')
+
+    return () => ws.close()
+  }, [runId])
+
+  if (error) {
+    return (
+      <main>
+        <h1>Run {runId}</h1>
+        <p role="alert">Error: {error}</p>
+      </main>
+    )
+  }
+
   return (
     <main>
       <h1>Run {runId}</h1>
-      <p>Issue #{id} — run console TODO(#2): stream events from WS /ws/{runId}.</p>
+      <p>Issue #{id} — {status}</p>
+      <ul>
+        {events.map((ev, i) => (
+          <li key={i}>
+            <code>[{ev.ts}] {ev.type}</code>
+            {ev.text != null && <span>: {ev.text}</span>}
+            {ev.exit_code != null && <span> (exit {ev.exit_code})</span>}
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }


### PR DESCRIPTION
## Summary

Implements issue #20 — the vertical slice that wires the full orchestrator ↔ agent ↔ UI pipeline.

## Changes

### Go (orchestrator)
- **`internal/registry/registry.go`** — new `RunState` pub/sub event bus: buffered replay for late-connecting UIs, `done`-channel termination, non-blocking fan-out so a stalled UI never blocks agent ingest
- **`internal/runner/runner.go`** — `LocalDocker` `AgentRunner` impl via `exec.Command`; uses `--network=host` so containers reach the orchestrator on `127.0.0.1`; injects `MIRDAIN_RUN_ID`, `MIRDAIN_RUN_SECRET`, `MIRDAIN_ORCHESTRATOR_URL` — no GitHub write credentials in the container
- **`cmd/mirdain/main.go`** — four new routes:
  - `POST /api/runs` — creates registry entry, launches container, rolls back on failure
  - `GET /api/runs/{id}` — returns run status JSON
  - `GET /internal/agent/{run_id}` — WS for agent; validates `?secret=` (→ 401 on mismatch), publishes events, terminates on `run.completed`
  - `GET /ws/{run_id}` — WS for UI; replays event buffer then streams live, drains cleanly on termination

### TypeScript (bridge stub)
- **`agent/src/bridge.ts`** — connects to orchestrator WS with run credentials, emits `run.started` → `text.delta` → `run.completed`, then exits
- **`agent/package.json`** + **`agent/tsconfig.json`** — `ws` dependency, `tsc` build to `dist/`

### SPA
- **`IssueDetailPage`** — "Start agent" button → `POST /api/runs` → navigate to run console; renders error element on failure
- **`RunDetailPage`** — WS client to `/ws/{runId}`, renders events in order; uses `wss://` when served over HTTPS

### Docker / infra
- **`Dockerfile`** — multi-stage build: compiles bridge in `node:20-slim`, runtime image copies `dist/` + `node_modules/`, sets `CMD ["node", "/app/dist/bridge.js"]`
- **`Makefile`** — `agent-build` target added
- **`.gitignore`** — excludes `agent/node_modules/` and `agent/dist/`

## Design notes
- **Container reachability**: `--network=host` (Linux/CI). macOS Docker Desktop has a VM boundary — known limitation for local Mac dev; primary target is Linux/CI.
- **Non-blocking fan-out**: `Publish()` uses `select { case ch <- data: default: }` so slow UI subscribers never stall agent ingest.
- **Buffered event replay**: late-connecting UI WebSockets receive the full event buffer before live events, handling the race where the agent completes before the browser connects.
- **Registry rollback**: entry is created before `runner.Start()` (agent connects immediately), but removed on `docker run` failure.

Closes #20